### PR TITLE
Fix gradle dependency in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,7 @@ with Maven:
 with Gradle:
 [source,groovy]
 ----
-implementation 'javafx-weaver-spring-boot-starter:1.3.0'
+implementation 'net.rgielen:javafx-weaver-spring-boot-starter:1.3.0'
 ----
 
 ==== Manual Setup


### PR DESCRIPTION
Extremely small change. Fixes the gradle dependency in the readme as it is missing the `net.rgielen`.