### PR TITLE
#24 Support for new Spring Boot 2.7+ autoconfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
         <character.encoding>UTF-8</character.encoding>
         <java.level>1.8</java.level>
         <project.build.sourceEncoding>${character.encoding}</project.build.sourceEncoding>
-        <slf4j.version>1.7.28</slf4j.version>
-        <spring-framework.version>5.1.8.RELEASE</spring-framework.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <spring-framework.version>5.3.31</spring-framework.version>
         <javafx.version>11.0.2</javafx.version>
-        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.7.18</spring-boot.version>
     </properties>
 
     <modules>

--- a/spring-boot/autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring-boot/autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration = net.rgielen.fxweaver.spring.boot.autoconfigure.FxWeaverAutoConfiguration

--- a/spring-boot/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot/autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+net.rgielen.fxweaver.spring.boot.autoconfigure.FxWeaverAutoConfiguration


### PR DESCRIPTION
- Added support for new Spring Boot 2.7+ autoconfiguration (mandatory for Spring Boot 3.0), 
- updated other dependencies based on the Spring Boot 2.7.18 
- Tested with sample project and in personal project